### PR TITLE
신현호 2주차 2회 풀이 업로드

### DIFF
--- a/현호/BOJ_18258.js
+++ b/현호/BOJ_18258.js
@@ -1,0 +1,90 @@
+class Node {
+  constructor(item) {
+    this.item = item;
+    this.next = null;
+  }
+}
+
+class Queue {
+  constructor() {
+    this.front = null;
+    this.rear = null;
+    this.size = 0;
+  }
+
+  enQueue(item) {
+    const node = new Node(item);
+    if (this.front === null) {
+      this.front = node;
+      this.front.next = this.rear;
+    } else this.rear.next = node;
+    this.rear = node;
+    this.size += 1;
+  }
+
+  deQueue() {
+    if (this.size === 1) {
+      const temp = this.front.item;
+      this.front = null;
+      this.rear = null;
+      this.size -= 1;
+      return temp;
+    } else if (this.size === 2) {
+      const temp = this.front.item;
+      const front = this.front.next;
+      this.front = front;
+      this.rear = front;
+      this.size -= 1;
+      return temp;
+    } else if (this.size > 2) {
+      const temp = this.front.item;
+      this.front = this.front.next;
+      this.size -= 1;
+      return temp;
+    }
+  }
+
+  getSize() {
+    return this.size;
+  }
+
+  printFront() {
+    return this.front.item;
+  }
+
+  printBack() {
+    return this.rear.item;
+  }
+}
+
+const fs = require("fs");
+const input = fs.readFileSync("/dev/stdin").toString().trim().split("\n");
+const command_amount = input.shift();
+const queue = new Queue();
+const result = [];
+
+for (let i = 0; i < command_amount; i += 1) {
+  const size = queue.getSize();
+
+  switch (input[i]) {
+    case "pop":
+      result.push(size ? queue.deQueue() : -1);
+      break;
+    case "front":
+      result.push(size ? queue.printFront() : -1);
+      break;
+    case "back":
+      result.push(size ? queue.printBack() : -1);
+      break;
+    case "size":
+      result.push(size);
+      break;
+    case "empty":
+      result.push(size ? 0 : 1);
+      break;
+    default:
+      queue.enQueue(input[i].split(" ")[1]);
+      break;
+  }
+}
+console.log(result.join("\n"));

--- a/현호/BOJ_2164.js
+++ b/현호/BOJ_2164.js
@@ -1,0 +1,62 @@
+class Node {
+  constructor(item) {
+    this.item = item;
+    this.next = null;
+  }
+}
+
+class Queue {
+  constructor() {
+    this.front = null;
+    this.rear = null;
+    this.size = 0;
+  }
+
+  enQueue(item) {
+    const node = new Node(item);
+    if (this.front === null) {
+      this.front = node;
+      this.front.next = this.rear;
+    } else this.rear.next = node;
+    this.rear = node;
+    this.size += 1;
+  }
+
+  deQueue() {
+    if (this.size === 1) {
+      const temp = this.front.item;
+      this.front = null;
+      this.rear = null;
+      this.size -= 1;
+      return temp;
+    } else if (this.size === 2) {
+      const temp = this.front.item;
+      const front = this.front.next;
+      this.front = front;
+      this.rear = front;
+      this.size -= 1;
+      return temp;
+    } else if (this.size > 2) {
+      const temp = this.front.item;
+      this.front = this.front.next;
+      this.size -= 1;
+      return temp;
+    }
+  }
+
+  getSize() {
+    return this.size;
+  }
+}
+
+const fs = require("fs");
+const input = fs.readFileSync("/dev/stdin").toString().split(" ").map(Number);
+let queue = new Queue();
+
+for (let i = 1; i <= input[0]; i++) queue.enQueue(i);
+while (queue.getSize() > 1) {
+  queue.deQueue();
+  let temp = queue.deQueue();
+  queue.enQueue(temp);
+}
+console.log(queue.deQueue());


### PR DESCRIPTION
# Info

[[BOJ] 큐2](https://www.acmicpc.net/problem/18258)
[[BOJ] 카드2](https://www.acmicpc.net/problem/2164)

## 풀이

자바스크립트에서는 자체적으로 큐를 지원하지 않기때문에 직접 구현하여 사용했습니다. (자바스크립트에서는 queue 대신 array를 queue처럼 사용할 수 있도록 내장 배열함수를 지원합니다 array.shift() / array.pop())

꼭 큐를 구현하여서 풀어야만 하는것은 아니지만, array.shift는 일반적인 queue의 deque의 속도보다 느립니다. 설명은 본헌님께서 자세하게 달아주셨더라구요 :)

## 새로 알게된 사실


## 여담
