### PR TITLE
장병준 3주차 2회 풀이 업로드

### DIFF
--- a/병준/BOJ_10799.java
+++ b/병준/BOJ_10799.java
@@ -1,0 +1,34 @@
+package algorithm;
+/*
+문제 : 쇠 막대기 (10799)
+ */
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Stack;
+
+public class BOJ_10799 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        String inData = reader.readLine();
+        String[] data = inData.split("");
+        Stack<Character> stack = new Stack<>();
+        int answer = 0;
+        for (int i = 0; i < data.length; i++) {
+            if (data[i].equals("(")) stack.push('(');  // 여는 괄호는 스택에 추가
+            else if (!stack.isEmpty() && data[i].equals(")")) {
+                stack.pop();  // 닫는 괄호를 만나면 가장 최근의 여는 괄호를 스택에서 제거
+                // 레이저를 감지합니다. 이전 문자가 여는 괄호인 경우, 레이저로 간주
+                if (data[i - 1].equals("(")) {
+                    answer += stack.size();
+                    // 레이저에 의해 잘린 막대의 조각 수를 추가합니다. 스택의 크기는 현재 남아있는 막대의 수를 의미합니다.
+                } else {
+                    answer += 1;
+                    // 레이저가 아닌 경우, 막대의 끝을 의미하므로 조각 수를 1만큼 증가시킵니다.
+                }
+            }
+            System.out.print(answer);
+
+        }
+    }
+}


### PR DESCRIPTION
# Info
[백준_10799_쇠막대기](https://www.acmicpc.net/problem/10799)

## 풀이
문제가 이해가 되지 않아
입력을 그림으로 그려 풀었습니다.
여는 괄호는 추가를 계속 해줬으며, 직전이 여는 괄호이고 현재가 닫힌 괄호이면 레이저로 판별해 여는 괄호의 개수를 잘렸음을 판별했습니다.
다른 닫힌 괄호는 막대의 끝을 나타내 나올 때마다 1을 증가시켜 문제를 풀었습니다.

## 여담
[이해가 안 될때 그림을 그리면 좋을 것 같습니당.](https://velog.io/@junified7/JavaBaekJoon10799%EC%87%A0-%EB%A7%89%EB%8C%80%EA%B8%B0%EC%8A%A4%ED%83%9D%EC%9D%98-%ED%99%9C%EC%9A%A9)
