### PR TITLE
신현호 4주차 1회 풀이 업로드

### DIFF
--- a/현호/BOJ_10026.js
+++ b/현호/BOJ_10026.js
@@ -1,0 +1,121 @@
+// 10026: 적록색약
+// 요약 : 적록색약인 사람들과 일반 사람들이 볼 수 있는 구역의 수를 나타내라
+// 좌표는 [y, x]
+
+const fs = require("fs");
+const input = fs.readFileSync("/dev/stdin").toString().trim().split("\n");
+
+const solve = () => {
+  const n = Number(input.shift());
+  const board = input.map((v) => v.split(""));
+  const answer = [];
+
+  answer.push(check(n, board, false));
+  answer.push(check(n, board, true));
+  console.log(answer.join(" "));
+};
+
+const check = (n, board, isColorWeakness) => {
+  const dx = [1, -1, 0, 0];
+  const dy = [0, 0, 1, -1];
+  const visited = Array.from({ length: n }, () => new Array(n).fill(false));
+  const queue = [];
+  let visitCount = 0;
+  let count = 1;
+
+  // 최초 노드 방문처리
+  queue.push({ axis: [0, 0], color: board[0][0] });
+  visited[0][0] = true;
+  visitCount += 1;
+
+  // visitCount가 n * n 보다 작을때까지 순환
+  while (visitCount < n * n) {
+    // 큐가 비어있다는 의미는 색상이 같은 노드를 더이상 찾을 수 없었음을 의미
+    // 따라서 색상이 인접한 모든 구역을 찾은 것 이므로 count + 1
+    if (!queue.length) {
+      // 방문하지 않은 노드 반환
+      const emptyAxis = findEmpty(visited);
+
+      // 더이상 방문할 노드가 없으면 다 찾은거니까 break
+      if (emptyAxis === -1) {
+        break;
+      }
+
+      // 방문처리
+      queue.push({ axis: emptyAxis, color: board[emptyAxis[0]][emptyAxis[1]] });
+      visited[emptyAxis[0]][emptyAxis[1]] = true;
+      visitCount += 1;
+      count += 1;
+    }
+
+    const { axis, color } = queue.shift();
+
+    // 상, 하, 좌, 우 탐색
+    for (let i = 0; i < 4; i += 1) {
+      const currYAxis = axis[0] + dy[i];
+      const currXAxis = axis[1] + dx[i];
+
+      // 좌표가 유효할 때
+      if (currXAxis >= 0 && currXAxis < n && currYAxis >= 0 && currYAxis < n) {
+        // 색약이 아닌 경우
+        if (!isColorWeakness) {
+          if (
+            !visited[currYAxis][currXAxis] &&
+            board[currYAxis][currXAxis] === color
+          ) {
+            queue.push({
+              axis: [currYAxis, currXAxis],
+              color: board[currYAxis][currXAxis],
+            });
+            visited[currYAxis][currXAxis] = true;
+            visitCount += 1;
+          }
+        }
+        // 색약인 경우
+        else {
+          if (
+            !visited[currYAxis][currXAxis] &&
+            checkColorWeakness(board[currYAxis][currXAxis], color)
+          ) {
+            queue.push({
+              axis: [currYAxis, currXAxis],
+              color: board[currYAxis][currXAxis],
+            });
+            visited[currYAxis][currXAxis] = true;
+            visitCount += 1;
+          }
+        }
+      }
+    }
+  }
+
+  return count;
+};
+
+const findEmpty = (visited) => {
+  for (let i = 0; i < visited.length; i += 1) {
+    for (let j = 0; j < visited.length; j += 1) {
+      if (!visited[i][j]) {
+        return [i, j];
+      }
+    }
+  }
+
+  return -1;
+};
+
+const checkColorWeakness = (currColor, nodeColor) => {
+  // 색약인 경우에는 R과 G을 동일하게 취급한다
+  if (
+    (currColor === "R" || currColor === "G") &&
+    (nodeColor === "R" || nodeColor === "G")
+  ) {
+    return true;
+  } else if (currColor === "B" && nodeColor === "B") {
+    return true;
+  }
+
+  return false;
+};
+
+solve();

--- a/현호/BOJ_2573.js
+++ b/현호/BOJ_2573.js
@@ -1,0 +1,131 @@
+// 2573: 빙산
+// 요약 : 빙산이 언제 두덩어리 이상으로 갈라지는지 계산하시오
+// bfs로 탐색을 모두 마쳤을 때 큐에 남아있는 원소의 개수와 탐색한 원소의 개수가 다르다면 두덩어리 이상으로 갈라졌음을 알수있다
+const fs = require("fs");
+const input = fs.readFileSync("/dev/stdin").toString().trim().split("\n");
+
+const dy = [0, 0, 1, -1];
+const dx = [1, -1, 0, 0];
+
+const solve = () => {
+  const [n, m] = input.shift().split(" ").map(Number);
+  const board = Array.from({ length: n }, (_, idx) =>
+    input[idx].split(" ").map(Number)
+  );
+  let queue = [];
+  let currDepth = 0;
+  let cnt = 0;
+
+  // queue에 노드 추가
+  // cnt는 아직 녹지 않은 빙산의 개수를 카운팅
+  for (let i = 0; i < n; i += 1) {
+    for (let j = 0; j < m; j += 1) {
+      if (board[i][j] !== 0) {
+        queue.push({ axis: [i, j], val: board[i][j], depth: 0 });
+        cnt += 1;
+      }
+    }
+  }
+
+  while (queue.length) {
+    // 1년이 지났을 경우
+    if (queue[0].depth !== currDepth) {
+      const temp_queue = [];
+
+      for (let i = 0; i < queue.length; i += 1) {
+        // 녹지 않은 빙산 카운팅
+        if (queue[i].val > 0) {
+          temp_queue.push(queue[i]);
+        }
+
+        // 빙산이 다 녹으면 cnt를 감소시킴
+        if (queue[i].val <= 0) {
+          cnt -= 1;
+        }
+
+        // board에 값 갱신
+        board[queue[i].axis[0]][queue[i].axis[1]] =
+          queue[i].val > 0 ? queue[i].val : 0;
+      }
+
+      // queue 갱신
+      queue = temp_queue;
+
+      // 빙산이 다 녹았으면 불가능하므로 0 리턴
+      if (cnt === 0) {
+        return 0;
+      }
+
+      // 빙산이 갈라졌는지 체크, 갈라졌으면 depth 리턴
+      if (isSplitted(n, m, queue, board)) {
+        return queue[0].depth;
+      }
+
+      currDepth += 1;
+    }
+
+    // 노드 체크
+    const { axis, val, depth } = queue.shift();
+    // 빙산 주위 빈칸 체크
+    let temp = 0;
+
+    for (let i = 0; i < 4; i += 1) {
+      const moveY = axis[0] + dy[i];
+      const moveX = axis[1] + dx[i];
+
+      if (
+        depth === currDepth &&
+        moveY >= 0 &&
+        moveY < n &&
+        moveX >= 0 &&
+        moveX < m
+      ) {
+        // 빈칸이 있으면 temp + 1
+        if (board[moveY][moveX] === 0) {
+          temp += 1;
+        }
+      }
+    }
+
+    // queue에 다음 노드 추가
+    queue.push({ axis, val: val - temp, depth: depth + 1 });
+  }
+
+  return 0;
+};
+
+// bfs로 빙산이 갈라졌는지 체크하는 로직
+// bfs로 탐색한 노드와 queue의 원소의 개수가 다르면 빙산이 갈라졌음을 체크할 수 있음
+const isSplitted = (n, m, queue, board) => {
+  const copy_queue = [...queue];
+  const visited = Array.from({ length: n }, () => new Array(m).fill(false));
+  const check_queue = [];
+  const { axis } = copy_queue.shift();
+  // 탐색한 노드의 개수
+  let cnt = 0;
+
+  check_queue.push(axis);
+  visited[axis[0]][axis[1]] = true;
+  cnt += 1;
+
+  while (check_queue.length) {
+    const [currY, currX] = check_queue.shift();
+
+    for (let i = 0; i < 4; i += 1) {
+      const moveY = currY + dy[i];
+      const moveX = currX + dx[i];
+
+      if (moveY >= 0 && moveY < n && moveX >= 0 && moveX < m) {
+        if (board[moveY][moveX] !== 0 && !visited[moveY][moveX]) {
+          visited[moveY][moveX] = true;
+          check_queue.push([moveY, moveX]);
+          cnt += 1;
+        }
+      }
+    }
+  }
+
+  return queue.length !== cnt;
+};
+
+console.log(solve());


### PR DESCRIPTION
# Info

기본문제 [10026: 적록색약](https://www.acmicpc.net/problem/10026)
응용문제 [2573: 빙산](https://www.acmicpc.net/problem/2573)

## 풀이

### 🏅 10026 적록색약

#### 📑 분석

1. 이 문제는 bfs로 풀 수 있다. (즉, 방문 처리만 해준다면 풀 수 있는 문제)
2. 적록색약은 R, G를 구분할 수 없다, 따라서 한가지 경우로 처리하면 된다.

가장 최상단, (0, 0)부터 시작해서 갈 수 있는 경로를 넣어서 확인한다.

#### 💡 아이디어

1. (0, 0) 부터 시작해서 인접한 똑같은 원소들을 다음 경로에 집어넣는다.
2. 탐색이 끝났다면 경우의 수 + 1을 해준다
3. visited 배열을 참조해서 방문하지 않은 첫번째 노드를 다시 넣어준다
4. [2-3]번 계속 반복
5. visited 배열이 모두 1로 채워졌다면 stop

다만, 종료여부 판별을 visited를 모두 순회해서 체크하는건 너무 비효율적이므로 별도의 count를 만들면 되지 않을까

### 🏅 2573 빙산

#### 📑 분석

1. 숫자가 들어있는 좌표 큐에 싸그리 넣고 상하좌우 빈칸있는지 확인해서 그만큼 차감
2. 차감했을 때 값이 0 이하로 떨어지면 다 녹은것으로 간주해서 count 차감
3. 최초 큐에 들어갔던 값들 (depth로 계산하면 될듯)이 다 빠졌으면 1년이 지난것으로 계산
4. 시작지점 아무거나 잡아서 bfs 서치 했을 때 search완료한 원소 개수와 현재 있는 count가 같지 않다면 두덩이 이상으로 갈라졌음을 알 수 있을듯

## 새로 알게된 사실

## 여담
