### PR TITLE
홍혜민 4주차 1회 풀이 업로드 

### DIFF
--- a/혜민/BOJ_7562.py
+++ b/혜민/BOJ_7562.py
@@ -1,0 +1,32 @@
+from collections import deque
+
+t = int(input())
+
+def bfs() :
+    dx = [-1, 1, 2, 2, 1, -1, -2, -2]       #8개의 모든 이동 방향을 설정
+    dy = [2, 2, 1, -1, -2, -2, -1, 1]
+
+    queue = deque()
+    queue.append((start_X, start_Y))
+    while queue :
+        x, y = queue.popleft()
+
+        if x == end_X and y == end_Y :  #목적지 도착했다면 종료 
+            return graph[x][y] -1 
+        
+        for i in range(8):      #8개의 이동 방향을 돌면서 다음 좌표로 이동 
+            nx = x + dx[i]
+            ny = y + dy[i]
+            if 0 <= nx < n and 0 <= ny < n and graph[nx][ny] == 0 : #다음 위치가 좌표에 벗어나지 않고 아직 방문 안했다면
+                graph[nx][ny] = graph[x][y] + 1     #다음 좌표 값에 +1
+                queue.append((nx,ny))       #다음 좌표 큐에 삽입 
+                
+        
+for _ in range(t) :
+    n = int(input)
+    start_X, start_Y = map(int, input().split())    #출발 좌표 입력
+    end_X, end_Y = map(int, input().split())        #목적지 좌표 입력
+
+    graph = [[0] * n for _ in range(n)]
+    graph[start_X][start_Y] = 1         #출발지는 방문했으므로 1로 설정 
+    print(bfs())


### PR DESCRIPTION
# Info
[나이트의 이동
](https://www.acmicpc.net/problem/7562)

- 간단 문제 설명 
입력 : 테스트케이스 수, 좌표 크기, 시작 좌표, 목적지 좌표 
출력 : 나이트의 최소 이동 수 
8개의 방향으로만 이동할 수 있는 나이트가 시작 좌표에서 시작하였을때, 목적지 좌표까지 이동하는 최소 이동수를 구하는 문제입니다. 

## 풀이

- 좌표 이동하는 bfs 문제와 비슷하지만 이동 좌표가 이전과 다름
- 총 8가지의 이동 방법이 있으며, 이동은 오른쪽 +2, 위쪽 +1 등등 으로 이동함
- 따라서 이동 좌표인 dx, dy 설정해줄 때, 8가지 케이스에 대해서 다 정의해준 후 bfs로 이동하면 됨
- 마지막에 목적지 좌표에 도착하였을때 return 값으로 해당 좌표의 값을 출력하면 되는데, 여기서 주의할 점은 -1을 해줘야 첫 시작점 좌표를 제외할 수 있음

## 새로 알게된 사실

## 여담
저도 더 풀고 푼 문제들 업로드 하겠습니다 :) 
