### PR TITLE
홍혜민 4주차 2회 풀이 업로드

### DIFF
--- a/혜민/BOJ_1012.py
+++ b/혜민/BOJ_1012.py
@@ -1,0 +1,29 @@
+import sys
+sys.setrecursionlimit(10000)  # 재귀 깊이 제한을 적절한 값으로 설정
+
+T = int(input())
+
+def dfs(x, y):
+    if x < 0 or x >= n or y < 0 or y >= m:  #위치가 그래프를 벗어났다면 False
+        return False
+    if graph[x][y] == 1:       #배추가 있다면 0으로 방문처리하고, 재귀함수로 상하좌우 좌표를 다시 살펴보기
+        graph[x][y] = 0 
+        dfs(x-1, y)
+        dfs(x+1, y)
+        dfs(x, y-1)
+        dfs(x, y+1)
+        return True             #배추가 있는 곳이 다 끝났으면, 연결된 곳은 dfs로 다 방문했다는 뜻이므로 True
+    return False        #배추가 없는 곳이라면 False
+
+for _ in range(T):     
+    result = 0
+    n, m, cabbage = map(int, input().split())
+    graph = [[0 for _ in range(m)] for _ in range(n)]
+    for _ in range(cabbage):    
+        x, y = map(int, input().split())
+        graph[x][y] = 1
+    for i in range(n):             #맵을 돌면서 dfs()함수를 수행하고 True이면 result +=1
+        for j in range(m):
+            if dfs(i, j) == True:
+                result += 1
+    print(result)


### PR DESCRIPTION
# Info

[유기농 배추
](https://www.acmicpc.net/problem/1012)

- 문제요약
맵에 배추가 있는 곳은 1, 없는 곳은 0으로 표기 되어있다.
배추벌레를 풀어놓으면 배추를 보호할 수 있고, 배추가 연결된 곳은 배추벌레를 1마리만 풀어도 됨.
고로 배추가 모여있는 곳을 카운팅 해야함 

## 풀이

- 1로 연결된 곳을 찾고 찾고 들어가는 것으로 생각하여, 전 dfs로 풀었습니다. 
- 현재 좌표를 x,y에 넣고 dfs를 돌리고, 배추가 있는 곳이라면 방문처리하고 그 좌표의 상하좌우를 또 재귀함수로 돌면서 탐색해나갑니다. 
- 유효하지 않거나 방문한 좌표이면 false를, 연결된 지점까지 다 돌면 true를 리턴합니다. 
- for n, m으로 맵을 돌면서 dfs 값이 true이면 result 값을 1 증가 시키고 출력합니다. 

## 새로 알게된 사실

백준에 처음 돌렸을때, RecursionError가 나서 쳐보니까 dfs 함수에서 재귀 호출이 무한히 깊어지는 경우에 이런게 발생할 수 있다고 하고 이를 방지하려면 아래와 같이 재귀 깊이 제한을 설정해주면 된다고 합니다. 
```
import sys
sys.setrecursionlimit(10000)
```
이거 해주니까 바로 되더라구요 

## 여담

